### PR TITLE
[Firmware] Increasing the output power of the SI5351

### DIFF
--- a/Firmware/wspr-beacon-1.1.ino
+++ b/Firmware/wspr-beacon-1.1.ino
@@ -136,7 +136,7 @@ void initializeSI5351()
 {
     if (si5351.init(SI5351_CRYSTAL_LOAD_8PF, 0, SI5351_CAL_FACTOR))
         // Set CLK0 as TX OUT
-        si5351.drive_strength(SI5351_CLK0, SI5351_DRIVE_6MA);
+        si5351.drive_strength(SI5351_CLK0, SI5351_DRIVE_8MA);
     else
         errorLEDIndicationAndReboot();
 }


### PR DESCRIPTION
### Firmware update
Increasing the output signal power for the SI5351 IC (_change SI5351_DRIVE_6MA to SI5351_DRIVE_8MA_):
```cpp
void initializeSI5351()
{
    if (si5351.init(SI5351_CRYSTAL_LOAD_8PF, 0, SI5351_CAL_FACTOR))
        // Set CLK0 as TX OUT
        si5351.drive_strength(SI5351_CLK0, SI5351_DRIVE_8MA);
    else
        errorLEDIndicationAndReboot();
}
```