### PR TITLE
[GitHub Actions] Creating configuration for firmware build

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,4 +1,4 @@
-name: Build WSPR-beacon firmware
+name: Build firmware
 
 on:
   push:
@@ -25,10 +25,15 @@ jobs:
 
       - name: Install core
         run: |
-          # Update the index of available cores
           arduino-cli core update-index
-          # Install Arduino AVR core which includes support for Arduino Nano (Atmega328)
           arduino-cli core install arduino:avr
+
+      - name: Install libraries
+        run: |
+          arduino-cli lib install "Etherkit JTEncode@1.3.1"
+          arduino-cli lib install "Etherkit Si5351@2.1.4"
+          arduino-cli lib install "Time@1.6.1"
+          arduino-cli lib install "TinyGPSPlus@1.0.3"
 
       - name: Compile firmware
         run: |
@@ -37,8 +42,8 @@ jobs:
             arduino-cli compile --fqbn arduino:avr:nano:cpu=atmega328 $f
           done
 
-      - name: Upload hex artifacts
-        uses: actions/upload-artifact@v3
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: compiled-firmware
           path: |


### PR DESCRIPTION
Adding configuration for GitHub Actions to automatically build the firmware.

**Build parameters:**
- MCU: Atmega328P
- Build system: Arduino
- The build is triggered on changes to _.ino_ files in the **_Firmware_** directory during a PR or push to the **master** branch.