### PR TITLE
[GitHub Actions] Add concurrency groups and monthly schedule to workflows

### DIFF
--- a/.github/workflows/app-build-linux.yml
+++ b/.github/workflows/app-build-linux.yml
@@ -9,7 +9,13 @@ on:
     branches: [ "**" ]
     paths:
       - 'App/**'
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   app-build-linux:

--- a/.github/workflows/app-build-windows.yml
+++ b/.github/workflows/app-build-windows.yml
@@ -9,7 +9,13 @@ on:
     branches: [ "**" ]
     paths:
       - 'App/**'
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   app-build-windows:

--- a/.github/workflows/app-lint.yml
+++ b/.github/workflows/app-lint.yml
@@ -9,7 +9,13 @@ on:
     branches: [ "**" ]
     paths:
       - 'App/**'
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   app-lint:

--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -9,7 +9,13 @@ on:
     branches: [ "**" ]
     paths:
       - 'App/**'
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   app-tests:

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -11,7 +11,13 @@ on:
     paths:
       - 'Firmware/ATmega328P-based/**/*.ino'
       - 'Firmware/ATmega328P-based/**/*.yml'
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   firmware-build:


### PR DESCRIPTION
## Summary

Add `concurrency` groups and monthly `schedule` trigger to all CI/CD workflows.

## Changes

**Concurrency groups** (`cancel-in-progress: true`):
- Automatically cancels outdated workflow runs when a new commit is pushed to the same branch or PR
- Applied to all 5 workflows: `app-tests`, `app-lint`, `app-build-windows`, `app-build-linux`, `firmware-build`

**Monthly schedule** (`cron: '0 0 1 * *'`):
- Runs all workflows on the 1st of each month at 00:00 UTC
- Enables early detection of regressions caused by dependency updates, runner environment changes, or toolchain updates — even when the source code hasn't changed